### PR TITLE
feat: total text for cumulative rewards

### DIFF
--- a/src/language/en_us.json
+++ b/src/language/en_us.json
@@ -66,5 +66,8 @@
     "practice2": "You will begin <b>Practice Trial 2/3</b> in",
     "practice3": "You will begin <b>Practice Trial 3/3</b> in",
     "expt1": "You will begin <b>Main Block </b> in"
+  },
+  "cumulative_rew": {
+    "total": "Total:<br>"
   }
 }

--- a/src/timelines/taskTrial.js
+++ b/src/timelines/taskTrial.js
@@ -5,8 +5,8 @@ import frameSpike from '../trials/frameSpike'
 import choice from '../trials/choice'
 import costBenefits from '../trials/costBenefits'
 import pressBalloon from '../trials/pressBalloon'
-import cumulativeReward from '../trials/cumulativeReward'
 import rewardFeedback from '../trials/rewardFeedback'
+import cumulativeReward from '../trials/cumulativeReward'
 import taskEnd from '../trials/taskEnd'
 
 const taskTrial = (blockSettings, blockDetails, opts) => {
@@ -19,10 +19,10 @@ const taskTrial = (blockSettings, blockDetails, opts) => {
   let timeline = [
     // show condition
     fixation(500), // need ITI of ~500 btwn trials
-    rewardProbability(500, blockSettings.is_practice?opts:opts.prob),
-    frameSpike(700, blockSettings.is_practice?blockSettings.effort:opts.effort, blockSettings.is_practice?blockSettings.high_effort:opts.high_effort),
-    costBenefits(1500, blockSettings.is_practice?blockSettings.value:opts.value, blockSettings.is_practice?blockSettings.effort:opts.effort, blockSettings.is_practice?blockSettings.high_effort:opts.high_effort),
-    choice(5000, blockSettings.is_practice?blockSettings.value:opts.value, blockSettings.is_practice?blockSettings.effort:opts.effort, blockSettings.is_practice?blockSettings.high_effort:opts.high_effort, blockSettings.keys, blockSettings.is_practice?blockSettings.get_reward:opts.get_reward),
+    rewardProbability(500, blockSettings.is_practice ? opts : opts.prob),
+    frameSpike(700, blockSettings.is_practice ? blockSettings.effort : opts.effort, blockSettings.is_practice ? blockSettings.high_effort : opts.high_effort),
+    costBenefits(1500, blockSettings.is_practice ? blockSettings.value : opts.value, blockSettings.is_practice ? blockSettings.effort : opts.effort, blockSettings.is_practice ? blockSettings.high_effort : opts.high_effort),
+    choice(5000, blockSettings.is_practice ? blockSettings.value : opts.value, blockSettings.is_practice ? blockSettings.effort : opts.effort, blockSettings.is_practice ? blockSettings.high_effort : opts.high_effort, blockSettings.keys, blockSettings.is_practice ? blockSettings.get_reward : opts.get_reward),
     fixation(200),
     pressBalloon(25000, blockSettings.keys, blockSettings.is_practice),
     fixation(500),

--- a/src/trials/cumulativeReward.js
+++ b/src/trials/cumulativeReward.js
@@ -1,6 +1,7 @@
 import { eventCodes } from '../config/main'
 import { photodiodeGhostBox, pdSpotEncode } from '../lib/markup/photodiode'
 import { jsPsych } from 'jspsych-react'
+import { lang } from '../config/main'
 
 const cumulativeReward = (duration, is_practice) => {
 
@@ -12,7 +13,7 @@ const cumulativeReward = (duration, is_practice) => {
       const code = eventCodes.cumulativeReward
       let cumulative_reward = 0;
       let rewards = jsPsych.data.get().select('value').values
-      
+
       for(let i = 0; i < rewards.length; i++){
         let reward = rewards[i]
         if (is_practice){
@@ -27,7 +28,7 @@ const cumulativeReward = (duration, is_practice) => {
         }
       }
 
-      let stimulus = `<div class="effort-container"><h1>${(cumulative_reward).toFixed(2)}</h1>` + photodiodeGhostBox() + `</div>`
+      let stimulus = `<div class="effort-container"><h1>${lang.cumulative_rew.total}${(cumulative_reward).toFixed(2)}</h1>` + photodiodeGhostBox() + `</div>`
       document.getElementById('jspsych-content').innerHTML = stimulus
       setTimeout(() => {
         done()


### PR DESCRIPTION
this literally just adds 'total: ' before each cumulative reward value
which hopefully should help differentiate reward feedback and cumulative rewards